### PR TITLE
add iteratorsize SizeUnknown and add tests to tests

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -2,6 +2,7 @@
 Abstract type used as base type for the type created by the `@resumable` macro.
 """
 abstract type FiniteStateMachineIterator end
+Base.iteratorsize(::Type{T}) where T<:FiniteStateMachineIterator = Base.SizeUnknown()
 
 """
 Mutable struct that contains a single `UInt8`.


### PR DESCRIPTION
I added a method so that `collect` and array comprehensions work. In adding tests I noticed that the tests did a lot of printing, and very little testing (eg with the `@test` macro). So I converted the existing code to print to an `IOBuffer` and then check the contents, and changed all the other prints to tests. Fixes #5 