### PR TITLE
Added the possibility to have Type parameters for smart type dispatching

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,8 +15,10 @@ function get_args(func_def::Dict)
   kwarg_list = Vector{Symbol}()
   for arg in (func_def[:args]...,)
     arg_def = splitarg(arg)
-    push!(arg_list, arg_def[1])
-    arg_dict[arg_def[1]] = arg_def[3] ? Any : arg_dict[arg_def[1]] = arg_def[2]
+    if arg_def[1] != nothing
+      push!(arg_list, arg_def[1])
+      arg_dict[arg_def[1]] = arg_def[3] ? Any : arg_dict[arg_def[1]] = arg_def[2]
+    end
   end
   for arg in (func_def[:kwargs]...,)
     arg_def = splitarg(arg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,3 +159,27 @@ end
   @test collect(test_type_parameters(Float64, 1)) == [1.0, 2.0, 3.0, 4.0]
 end
 
+@resumable function test_type_parameters_order(start::Int64, ::Type{T})::T where {T}
+  for i in start:start+3
+    @yield T(i)
+  end
+end
+
+@testset "test_type_parameters_order" begin
+  @test collect(test_type_parameters_order(1, Int64)) == [1, 2, 3, 4]
+  @test collect(test_type_parameters_order(1, Float64)) == [1.0, 2.0, 3.0, 4.0]  
+  @test typeof(first(test_type_parameters_order(1, ComplexF32))) == ComplexF32
+end
+
+@resumable function test_type_parameters_optional(start::Int64; t::Type{T}=Type{Int64})::T where {T}
+  for i in start:start+3
+    @yield T(i)
+  end
+end
+
+
+@testset "test_type_parameters_optional" begin
+  @test collect(test_type_parameters_optional(1, t=Int64)) == [1, 2, 3, 4]
+  @test collect(test_type_parameters_optional(1, t=Float64)) == [1.0, 2.0, 3.0, 4.0]  
+  @test typeof(first(test_type_parameters_optional(1, t=ComplexF32))) == ComplexF32
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,3 +141,21 @@ end
   @test collect(test_continue()) == [1, 3, 4, 5, 6, 7, 8, 9, 10]
   @test collect(test_continue_double()) == [1, 3, 1, 3]
 end
+
+@resumable function test_type_parameters(::Type{Int64}, start::Int64)
+  for i in start:start+3
+    @yield i
+  end
+end
+
+@resumable function test_type_parameters(::Type{Float64}, start::Int64)
+  for i in start:start+3
+    @yield float(i)
+  end
+end
+
+@testset "test_type_parameters" begin
+  @test collect(test_type_parameters(Int64, 1)) == [1, 2, 3, 4]
+  @test collect(test_type_parameters(Float64, 1)) == [1.0, 2.0, 3.0, 4.0]
+end
+


### PR DESCRIPTION
Type params (i.e., ::Type{T} anonymous parameters), which are very useful for handling polymorphism-like multiple dispatching, can be simply discarded from the list of arguments since they are used only for the method dispatching and do not have any sensible nor useful value. 

In order to do that, the utils.jl file has been modified so that when such a parameter is present (whose name is nothing) it is skipped.

Some tests have been added to check whether type parameters are properly handled.