### PR TITLE
re-enable JET tests

### DIFF
--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -18,7 +18,7 @@ jobs:
         threads:
           - '1'
         jet:
-          - 'false'
+          - 'true'
         arch:
           - x64
     steps:


### PR DESCRIPTION
By accident I committed them as disabled when adding them to CI