### PR TITLE
Documentation fixes and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ end
 for fib in fibonacci(10)
   println(fib)
 end
+```
 
-# Example with specifies the length
+```julia
+# Example which specifies the length
 using ResumableFunctions
 
 @resumable length=n^2 function fibonacci(n::Int) :: Int

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # ResumableFunctions
 
-C# style generators a.k.a. semi-coroutines for Julia.
+*C# style generators a.k.a. semi-coroutines for Julia.*
 
 C# has a convenient way to create iterators using the `yield return` statement. The package `ResumableFunctions` provides the same functionality for the Julia language by introducing the `@resumable` and the `@yield` macros. These macros can be used to replace the `Task` switching functions `produce` and `consume` which were deprecated in Julia v0.6. `Channels` are the preferred way for inter-task communication in julia v0.6+, but their performance is subpar for iterator applications.
 
@@ -40,12 +40,14 @@ end
 
 `ResumableFunctions` is a registered package and can be installed by running:
 ```julia
+using Pkg
 Pkg.add("ResumableFunctions")
 ```
 
 ## Authors
 
 * Ben Lauwens, Royal Military Academy, Brussels, Belgium.
+* JuliaDynamics and QuantumSavory volunteers.
 
 ## License
 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -188,7 +188,7 @@ ERROR: @resumable function has stopped!
 DocTestSetup = nothing
 ```
 
-When the `@resumable function` returns normally an error will be thrown if called again.
+When the `@resumable function` returns normally (i.e. at the end of the function rather than at a `@yield` point), an error will be thrown if called again.
 
 ## Two-way communication
 
@@ -320,7 +320,7 @@ DocTestSetup = nothing
 
 ## Parametric `@resumable` functions
 
-Type parameters can be specified with a `where` clause:
+Type parameters can be specified with a normal Julia `where` clause:
 
 ```@meta
 DocTestSetup = quote
@@ -388,6 +388,7 @@ end
 @resumable function arrays_of_tuples()
   for u in [[(1,2),(3,4)], [(5,6),(7,8)]]
     for i in 1:2
+      local val
       let i=i
         val = [a[i] for a in u]
       end


### PR DESCRIPTION
* Many typo and grammar fixes 
* Clarification improvements - a couple of long sentences that were hard to read have been split into bullet points or separate sentence clauses
* Replaced the old pre-Julia-1.0 style iterator interface shown in the "internals" page with the correct `iterate` interface that's actually used by the package
* Fix install instructions to import `Pkg` first, and sync the authors list with what's in the README