### PR TITLE
Add support for comprehensions with conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v1.0.4 - 2025-08-25
+
+- Support comprehensions with conditionals, e.g., `@resumable function f1(); [i for i in 1:10 if i<5]; end` which previously led to "Illegal expression" errors.
+
 ## v1.0.3 - 2025-03-24
 
 - Internal changes to `fsmi_generator` to support julia 1.12

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ license = "MIT"
 desc = "C# sharp style generators a.k.a. semi-coroutines for Julia."
 authors = ["Ben Lauwens and volunteer maintainers"]
 repo = "https://github.com/JuliaDynamics/ResumableFunctions.jl.git"
-version = "1.0.3"
+version = "1.0.4"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/test/test_main.jl
+++ b/test/test_main.jl
@@ -403,6 +403,42 @@ end
     end
   end
   @test collect(test_comprehension5()) == [2, 3, 4, 3, 4, 5]
+
+  @resumable function test_comprehension_state()
+    c = 1
+    @yield [i*c for i in 1:5]
+    c += 1
+    @yield [i*c for i in 1:5]
+  end
+  @test_broken collect(test_comprehension_state()) == [[1, 2, 3, 4, 5], [2, 4, 6, 8, 10]]
+
+  @resumable function test_comprehension_if()
+    @yield [i for i in 1:10 if i < 5]
+  end
+  @test collect(test_comprehension_if()) == [[1, 2, 3, 4]]
+
+  @resumable function test_comprehension_if_multi_iterators()
+    @yield [i + j for i in 1:3, j in 1:3 if i <= j]
+  end
+  @test collect(test_comprehension_if_multi_iterators()) == [[2, 3, 4, 4, 5, 6]]
+
+  @resumable function test_comprehension_if_nested_for()
+    @yield [i * j for i in 1:3 for j in 1:3 if i * j < 5]
+  end
+  @test collect(test_comprehension_if_nested_for()) == [[1, 2, 3, 2, 4, 3]]
+
+  @resumable function test_comprehension_if_mixed()
+    @yield [i + j + k for i in 1:2, j in 1:2 for k in 1:2 if i + j + k == 4]
+  end
+  @test collect(test_comprehension_if_mixed()) == [[4, 4, 4]]
+
+  @resumable function test_comprehension_if_state()
+    c = 1
+    @yield [i for i in 1:10 if i < c]
+    c += 1
+    @yield [i for i in 1:10 if i < c]
+  end
+  @test_broken collect(test_comprehension_if_state()) == [Int[], [1]]
 end
 
 @testset "test_ref" begin


### PR DESCRIPTION
Attempt to fix #129 

Comprehension support works by parsing the underlying generators, and generators with `if` conditions have `filter` as their `Expr` form's second argument. This previously wasn't supported, as the generator parsing code expected the `for` iteration's `=` to be the second arg instead. 

This change adds support for the case of generators with filters, and adds relevant tests.