### PR TITLE
Fix JET name collisions in @resumable expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v1.0.6 - 2026-04-23
+
+- (internal) switch to a reimplementation of `gensym` that is not replayable by JET.jl (see https://github.com/aviatesk/JET.jl/issues/814)
+
 ## v1.0.5 - 2026-03-20
 
 - Some general cleanup of the code

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ license = "MIT"
 desc = "C# sharp style generators a.k.a. semi-coroutines for Julia."
 authors = ["Ben Lauwens and volunteer maintainers"]
 repo = "https://github.com/JuliaDynamics/ResumableFunctions.jl.git"
-version = "1.0.5"
+version = "1.0.6"
 
 [deps]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"

--- a/src/macro.jl
+++ b/src/macro.jl
@@ -115,7 +115,7 @@ macro resumable(ex::Expr...)
   pushfirst!(args, functional)
 
   # The finite state machine structure definition
-  type_name = gensym(Symbol(func_def[:name], :_FSMI))
+  type_name = fresh_binding_name(Symbol(func_def[:name], :_FSMI))
   constr_def = copy(func_def)
   slot_T = [gensym(s) for s in keys(slots)]
   slot_T_sub = [:($k <: $v) for (k, v) in zip(slot_T, values(slots))]
@@ -152,7 +152,7 @@ macro resumable(ex::Expr...)
     bareconst_expr = nothing
   end
   constr_expr = combinedef(constr_def) |> flatten
-  typed_fsmi = VERSION >= v"1.10.0-DEV.873" ? gensym(:typed_fsmi) : typed_fsmi_fallback
+  typed_fsmi = VERSION >= v"1.10.0-DEV.873" ? fresh_binding_name(:typed_fsmi) : typed_fsmi_fallback
   type_expr = quote
     mutable struct $struct_name
       _state :: UInt8

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,6 +59,14 @@ function forward_args(func_def)
 end
 
 const unused = (Symbol("#temp#"), Symbol("_"), Symbol(""), Symbol("#unused#"), Symbol("#self#"))
+const fresh_binding_counter = Base.Threads.Atomic{UInt}(0)
+
+# JET/Revise can replay macro expansion in a way that makes plain `gensym()`
+# collide for top-level bindings. Use an explicit module-global counter there.
+function fresh_binding_name(prefix=:resumable)
+  id = Base.Threads.atomic_add!(fresh_binding_counter, UInt(1)) + UInt(1)
+  return Symbol("##", prefix, "#", Base.get_world_counter(), "#", id)
+end
 
 function strip_defaults(arg_exprs::Vector{Any})
   return Any[@capture(arg_expr, arg_expr2_ = default_) ? arg_expr2 : arg_expr
@@ -70,7 +78,7 @@ Function returning the slots of a function definition
 """
 function get_slots(func_def::Dict, args::Dict{Symbol, Any}, mod::Module)
   slots = Dict{Symbol, Any}()
-  func_def[:name] = gensym()
+  func_def[:name] = fresh_binding_name(:inferfn)
   func_def[:args] = Any[strip_defaults(func_def[:args])..., strip_defaults(func_def[:kwargs])...]
   func_def[:kwargs] = []
   # replace yield with inference barrier


### PR DESCRIPTION
## Summary
- make top-level generated names in `@resumable` collision-resistant under JET/Revise replay
- keep the fix minimal by changing only the generated binding names
- preserve the current inference path from PR #147

## Root cause
`JET.report_package` replays top-level definitions through Revise/JuliaInterpreter. In that path, plain `gensym()`-derived top-level bindings from separate `@resumable` expansions can collide, which makes different helper methods and generated types share the same name.

That is why `only(methods(inferfn, Tuple))` started failing after PR #147: it was seeing multiple methods attached to a collided helper binding, not a genuine ambiguity in the resumable function being analyzed.

## Verification
Reproduced and fixed with a clean direct CLI run, outside the package test runner:

```julia
using JET, QuantumSavory
rep = JET.report_package(QuantumSavory; target_modules=(QuantumSavory,))
length(JET.get_reports(rep)) == 0
```
