### PR TITLE
POC: Use JuliaLowering.jl for finite state machine generation (#99)

### DIFF
--- a/src/macro_lowered.jl
+++ b/src/macro_lowered.jl
@@ -1,0 +1,31 @@
+using JuliaLowering
+using JuliaSyntax
+
+macro resumable(ex)
+    # 1. Parse using JuliaSyntax
+    st = JuliaSyntax.parsestmt(JuliaLowering.SyntaxTree, string(ex))
+    
+    # 2. Lower
+    lowered = JuliaLowering.lower(__module__, st)
+    code = JuliaLowering.to_lowered_expr(lowered)
+    
+    # 3. Extract CodeInfo
+    ci = nothing
+    if code.head === :thunk && code.args[1] isa Core.CodeInfo
+        for stmt in code.args[1].code
+            if stmt isa Expr && stmt.head === :method && length(stmt.args) >= 3 && stmt.args[3] isa Core.CodeInfo
+                ci = stmt.args[3]
+                break
+            end
+        end
+    end
+    if ci === nothing
+        error("Could not lower to method CodeInfo")
+    end
+    
+    # 4. Generate the struct and stepping function from CodeInfo
+    # (Proof of concept)
+    return quote
+        println("Resumable FSM generated from JuliaLowering CodeInfo!")
+    end
+end


### PR DESCRIPTION
This is a draft proof-of-concept for issue #99. It explores using `JuliaLowering.jl` to extract a flat linear IR (`CodeInfo`) and using it to directly generate the finite state machine, bypassing complex AST rewrites and scoping logic.